### PR TITLE
Build static bullet libs by default

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -30,7 +30,7 @@ class BulletConan(ConanFile):
         "network_support": [True, False],
     }
     default_options = \
-        "shared=True",\
+        "shared=False",\
         "fPIC=True",\
         "bullet3=False",\
         "graphical_benchmark=False",\


### PR DESCRIPTION
Build static libs by default:
- This would make bullet have the same behavior as the other conan libs
- shared libraries do not work on windows: https://github.com/bulletphysics/bullet3/issues/1570
They do work on linux.
